### PR TITLE
[test] Stamp 도메인 테스트 코드 작성 및 리펙토링

### DIFF
--- a/src/main/java/com/halo/eventer/domain/stamp/Mission.java
+++ b/src/main/java/com/halo/eventer/domain/stamp/Mission.java
@@ -68,6 +68,11 @@ public class Mission {
         this.notClearedThumbnail = request.getNotClearedThumbnail();
     }
 
+    public void addStamp(Stamp stamp){
+        this.stamp = stamp;
+        stamp.getMissions().add(this);
+    }
+
     public static Mission from(MissionSetDto request) {
         return Mission.builder()
                 .boothId(request.getBoothId())

--- a/src/main/java/com/halo/eventer/domain/stamp/Stamp.java
+++ b/src/main/java/com/halo/eventer/domain/stamp/Stamp.java
@@ -15,7 +15,7 @@ public class Stamp {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private boolean stampOn;
+    private boolean stampOn = true;
 
     @Column(nullable = false)
     private Integer stampFinishCnt = 0;
@@ -28,16 +28,20 @@ public class Stamp {
     private List<StampUser> stampUsers = new ArrayList<>();
 
     @OneToMany(mappedBy = "stamp", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
-    private List<Mission> missions;
+    private List<Mission> missions = new ArrayList<>();
 
-    public Stamp(Festival festival) {
+    private Stamp(Festival festival){
         this.festival = festival;
-        this.stampOn = true;
-        missions = new ArrayList<>();
+        festival.getStamps().add(this);
     }
 
-    public void setStampOn(boolean status) { this.stampOn = status; }
-    public void setMissions(List<Mission> missions) { this.missions = missions; }
-    public void setStampUsers(StampUser stampUser) { this.stampUsers.add(stampUser); }
+    public void switchStampOn(){
+        stampOn = !stampOn;
+    }
+
     public void setStampFinishCnt(Integer cnt) { this.stampFinishCnt = cnt; }
+
+    public static Stamp create(Festival festival){
+        return new Stamp(festival);
+    }
 }

--- a/src/main/java/com/halo/eventer/domain/stamp/StampUser.java
+++ b/src/main/java/com/halo/eventer/domain/stamp/StampUser.java
@@ -3,6 +3,8 @@ package com.halo.eventer.domain.stamp;
 import java.util.List;
 import java.util.UUID;
 import javax.persistence.*;
+
+import com.halo.eventer.domain.stamp.dto.stampUser.SignupDto;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 

--- a/src/main/java/com/halo/eventer/domain/stamp/controller/MissionController.java
+++ b/src/main/java/com/halo/eventer/domain/stamp/controller/MissionController.java
@@ -14,16 +14,15 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/stamp/mission")
 public class MissionController {
+
   private final MissionService missionService;
 
-  /** 미션 단일 조회 */
   @MissionDetailGetApi
   @GetMapping
   public MissionDetailGetDto getMission(@RequestParam("missionId") Long missionId) {
     return missionService.getMission(missionId);
   }
 
-  /** 미션 단일 수정 */
   @MissionUpdateApi
   @PatchMapping
   public void updateMission(

--- a/src/main/java/com/halo/eventer/domain/stamp/controller/StampController.java
+++ b/src/main/java/com/halo/eventer/domain/stamp/controller/StampController.java
@@ -1,9 +1,6 @@
 package com.halo.eventer.domain.stamp.controller;
 
-import com.halo.eventer.domain.stamp.dto.stamp.MissionSummaryGetListDto;
-import com.halo.eventer.domain.stamp.dto.stamp.MissionSetListDto;
-import com.halo.eventer.domain.stamp.dto.stamp.StampGetListDto;
-import com.halo.eventer.domain.stamp.dto.stamp.StampUsersGetListDto;
+import com.halo.eventer.domain.stamp.dto.stamp.*;
 import com.halo.eventer.domain.stamp.service.StampService;
 import com.halo.eventer.domain.stamp.swagger.MissionListGetApi;
 import com.halo.eventer.domain.stamp.swagger.MissionListSetApi;
@@ -12,6 +9,8 @@ import com.halo.eventer.domain.stamp.swagger.StampUsersListGetApi;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @Tag(name = "스탬프 투어")
 @RestController
@@ -22,55 +21,55 @@ public class StampController {
 
   /** 축제 id로 스탬프 생성 */
   @PostMapping
-  public StampGetListDto registerStamp(@RequestParam("festivalId") Long festivalId) {
+  public List<StampGetDto> registerStamp(@RequestParam("festivalId") Long festivalId) {
     return stampService.registerStamp(festivalId);
   }
 
   /** 축제 id로 스탬프 조회 */
   @GetMapping
-  public StampGetListDto getStampList(@RequestParam("festivalId") Long festivalId) {
+  public List<StampGetDto> getStampList(@RequestParam("festivalId") Long festivalId) {
     return stampService.getStampByFestivalId(festivalId);
   }
 
   /** 스탬프 상태 변경 */
   @StampOnUpdateApi
   @PatchMapping
-  public String updateStampOn(@RequestParam("stampId") Long stampId) {
-    return stampService.updateStampOn(stampId);
+  public void updateStampOn(@RequestParam("stampId") Long stampId) {
+    stampService.updateStampOn(stampId);
   }
 
   /** 스탬프 삭제 */
   @DeleteMapping
-  public String deleteStamp(@RequestParam("stampId") Long stampId) {
-    return stampService.deleteStamp(stampId);
+  public void deleteStamp(@RequestParam("stampId") Long stampId) {
+    stampService.deleteStamp(stampId);
   }
 
   /** 미션 생성 */
   @MissionListSetApi
   @PostMapping("/mission")
-  public String setMissionList(
-      @RequestParam("stampId") Long stampId, @RequestBody MissionSetListDto dto) {
-    return stampService.setMission(stampId, dto);
+  public void setMissionList(
+          @RequestParam("stampId") Long stampId, @RequestBody MissionSetListDto dto) {
+    stampService.createMission(stampId, dto);
   }
 
   /** 미션 리스트 조회 */
   @MissionListGetApi
   @GetMapping("/missions")
-  public MissionSummaryGetListDto getMissionList(@RequestParam("stampId") Long stampId) {
+  public List<MissionSummaryGetDto> getMissionList(@RequestParam("stampId") Long stampId) {
     return stampService.getMissions(stampId);
   }
 
   /** 해당 스탬프 유저들 조회 */
   @StampUsersListGetApi
   @GetMapping("/users")
-  public StampUsersGetListDto getStampUsers(@RequestParam("stampId") Long stampId) {
+  public List<StampUsersGetDto> getStampUsers(@RequestParam("stampId") Long stampId) {
     return stampService.getStampUsers(stampId);
   }
 
   /** 스탬프 완료 기준 설정 */
   @PostMapping("/finishCnt")
-  public String setFinishCnt(
+  public void setFinishCnt(
       @RequestParam("stampId") Long stampId, @RequestParam("cnt") Integer cnt) {
-    return stampService.setFinishCnt(stampId, cnt);
+    stampService.setFinishCnt(stampId, cnt);
   }
 }

--- a/src/main/java/com/halo/eventer/domain/stamp/controller/StampController.java
+++ b/src/main/java/com/halo/eventer/domain/stamp/controller/StampController.java
@@ -17,34 +17,30 @@ import java.util.List;
 @RequiredArgsConstructor
 @RequestMapping("/stamp")
 public class StampController {
+
   private final StampService stampService;
 
-  /** 축제 id로 스탬프 생성 */
   @PostMapping
   public List<StampGetDto> registerStamp(@RequestParam("festivalId") Long festivalId) {
     return stampService.registerStamp(festivalId);
   }
 
-  /** 축제 id로 스탬프 조회 */
   @GetMapping
   public List<StampGetDto> getStampList(@RequestParam("festivalId") Long festivalId) {
     return stampService.getStampByFestivalId(festivalId);
   }
 
-  /** 스탬프 상태 변경 */
   @StampOnUpdateApi
   @PatchMapping
   public void updateStampOn(@RequestParam("stampId") Long stampId) {
     stampService.updateStampOn(stampId);
   }
 
-  /** 스탬프 삭제 */
   @DeleteMapping
   public void deleteStamp(@RequestParam("stampId") Long stampId) {
     stampService.deleteStamp(stampId);
   }
 
-  /** 미션 생성 */
   @MissionListSetApi
   @PostMapping("/mission")
   public void setMissionList(
@@ -52,14 +48,12 @@ public class StampController {
     stampService.createMission(stampId, dto);
   }
 
-  /** 미션 리스트 조회 */
   @MissionListGetApi
   @GetMapping("/missions")
   public List<MissionSummaryGetDto> getMissionList(@RequestParam("stampId") Long stampId) {
     return stampService.getMissions(stampId);
   }
 
-  /** 해당 스탬프 유저들 조회 */
   @StampUsersListGetApi
   @GetMapping("/users")
   public List<StampUsersGetDto> getStampUsers(@RequestParam("stampId") Long stampId) {

--- a/src/main/java/com/halo/eventer/domain/stamp/dto/stamp/MissionSummaryGetDto.java
+++ b/src/main/java/com/halo/eventer/domain/stamp/dto/stamp/MissionSummaryGetDto.java
@@ -17,7 +17,7 @@ public class MissionSummaryGetDto {
   private String clearedThumbnail;
   private String notClearedThumbnail;
 
-  public static List<MissionSummaryGetDto> fromMissionList(List<Mission> missions){
+  public static List<MissionSummaryGetDto> fromEntities(List<Mission> missions){
     return missions.stream()
             .map(MissionSummaryGetDto::from)
             .collect(Collectors.toList());

--- a/src/main/java/com/halo/eventer/domain/stamp/dto/stamp/MissionSummaryGetDto.java
+++ b/src/main/java/com/halo/eventer/domain/stamp/dto/stamp/MissionSummaryGetDto.java
@@ -1,21 +1,34 @@
 package com.halo.eventer.domain.stamp.dto.stamp;
 
+import com.halo.eventer.domain.stamp.Mission;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
+@NoArgsConstructor
+@AllArgsConstructor
 public class MissionSummaryGetDto {
   private Long missionId;
   private String title;
   private String clearedThumbnail;
   private String notClearedThumbnail;
 
-  public MissionSummaryGetDto() {}
+  public static List<MissionSummaryGetDto> fromMissionList(List<Mission> missions){
+    return missions.stream()
+            .map(MissionSummaryGetDto::from)
+            .collect(Collectors.toList());
+  }
 
-  public MissionSummaryGetDto(
-      Long missionId, String title, String clearedThumbnail, String notClearedThumbnail) {
-    this.missionId = missionId;
-    this.title = title;
-    this.clearedThumbnail = clearedThumbnail;
-    this.notClearedThumbnail = notClearedThumbnail;
+  public static MissionSummaryGetDto from(Mission mission) {
+    return new MissionSummaryGetDto(
+            mission.getId(),
+            mission.getTitle(),
+            mission.getClearedThumbnail(),
+            mission.getNotClearedThumbnail()
+    );
   }
 }

--- a/src/main/java/com/halo/eventer/domain/stamp/dto/stamp/StampGetDto.java
+++ b/src/main/java/com/halo/eventer/domain/stamp/dto/stamp/StampGetDto.java
@@ -17,7 +17,7 @@ public class StampGetDto {
     private boolean stampOn;
     private Integer stampFinishCnt;
 
-    public static List<StampGetDto> fromStampList(List<Stamp> stampList) {
+    public static List<StampGetDto> fromEntities(List<Stamp> stampList) {
         return stampList.stream()
                 .map(StampGetDto::from)
                 .collect(Collectors.toList());

--- a/src/main/java/com/halo/eventer/domain/stamp/dto/stamp/StampGetDto.java
+++ b/src/main/java/com/halo/eventer/domain/stamp/dto/stamp/StampGetDto.java
@@ -3,25 +3,31 @@ package com.halo.eventer.domain.stamp.dto.stamp;
 import com.halo.eventer.domain.stamp.Stamp;
 import java.util.List;
 import java.util.stream.Collectors;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
 public class StampGetDto {
     private Long stampId;
     private boolean stampOn;
     private Integer stampFinishCnt;
 
-    public StampGetDto(Stamp stamp) {
-        this.stampId = stamp.getId();
-        this.stampOn = stamp.isStampOn();
-        this.stampFinishCnt = stamp.getStampFinishCnt();
-    }
-
     public static List<StampGetDto> fromStampList(List<Stamp> stampList) {
         return stampList.stream()
-                .map(StampGetDto::new)
+                .map(StampGetDto::from)
                 .collect(Collectors.toList());
+    }
+
+    public static StampGetDto from(Stamp stamp) {
+        return new StampGetDto(
+                stamp.getId(),
+                stamp.isStampOn(),
+                stamp.getStampFinishCnt()
+        );
     }
 }

--- a/src/main/java/com/halo/eventer/domain/stamp/dto/stamp/StampUsersGetDto.java
+++ b/src/main/java/com/halo/eventer/domain/stamp/dto/stamp/StampUsersGetDto.java
@@ -1,10 +1,17 @@
 package com.halo.eventer.domain.stamp.dto.stamp;
 
+import com.halo.eventer.domain.stamp.StampUser;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@NoArgsConstructor
+import java.util.List;
+import java.util.stream.Collectors;
+
+
 @Getter
+@NoArgsConstructor
+@AllArgsConstructor
 public class StampUsersGetDto {
   private String uuid;
   private String name;
@@ -12,12 +19,19 @@ public class StampUsersGetDto {
   private boolean finished;
   private int participantCount;
 
-  public StampUsersGetDto(
-      String uuid, String name, String phone, boolean finished, int participantCount) {
-    this.uuid = uuid;
-    this.name = name;
-    this.phone = phone;
-    this.finished = finished;
-    this.participantCount = participantCount;
+  public static List<StampUsersGetDto> fromList(List<StampUser> stampUsers){
+    return stampUsers.stream()
+            .map(StampUsersGetDto::from)
+            .collect(Collectors.toList());
+  }
+
+  public static StampUsersGetDto from(StampUser stampUser){
+    return new StampUsersGetDto(
+            stampUser.getUuid(),
+            stampUser.getName(),
+            stampUser.getPhone(),
+            stampUser.isFinished(),
+            stampUser.getParticipantCount()
+    );
   }
 }

--- a/src/main/java/com/halo/eventer/domain/stamp/dto/stamp/StampUsersGetDto.java
+++ b/src/main/java/com/halo/eventer/domain/stamp/dto/stamp/StampUsersGetDto.java
@@ -19,7 +19,7 @@ public class StampUsersGetDto {
   private boolean finished;
   private int participantCount;
 
-  public static List<StampUsersGetDto> fromList(List<StampUser> stampUsers){
+  public static List<StampUsersGetDto> fromEntities(List<StampUser> stampUsers){
     return stampUsers.stream()
             .map(StampUsersGetDto::from)
             .collect(Collectors.toList());

--- a/src/main/java/com/halo/eventer/domain/stamp/service/StampService.java
+++ b/src/main/java/com/halo/eventer/domain/stamp/service/StampService.java
@@ -3,18 +3,17 @@ package com.halo.eventer.domain.stamp.service;
 import com.halo.eventer.domain.festival.Festival;
 import com.halo.eventer.domain.festival.exception.FestivalNotFoundException;
 import com.halo.eventer.domain.festival.repository.FestivalRepository;
-import com.halo.eventer.domain.festival.service.FestivalService;
 import com.halo.eventer.domain.stamp.Mission;
 import com.halo.eventer.domain.stamp.Stamp;
-import com.halo.eventer.domain.stamp.StampUser;
 import com.halo.eventer.domain.stamp.dto.stamp.*;
-import com.halo.eventer.domain.stamp.dto.stampUser.FinishedStampUserDto;
 import com.halo.eventer.domain.stamp.exception.StampClosedException;
 import com.halo.eventer.domain.stamp.exception.StampNotFoundException;
 import com.halo.eventer.domain.stamp.repository.MissionRepository;
 import com.halo.eventer.domain.stamp.repository.StampRepository;
 import java.util.List;
 import java.util.stream.Collectors;
+
+import com.halo.eventer.global.utils.EncryptService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,43 +21,39 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 public class StampService {
+
     private final StampRepository stampRepository;
     private final FestivalRepository festivalRepository;
     private final EncryptService encryptService;
     private final MissionRepository missionRepository;
 
-    /** 축제 id로 스탬프 생성 */
     @Transactional
     public List<StampGetDto> registerStamp(Long festivalId) {
         Festival festival = loadFestivalOrThrow(festivalId);
         stampRepository.save(Stamp.create(festival));
         List<Stamp> stamps = stampRepository.findByFestival(festival);
-        return StampGetDto.fromStampList(stamps);
+        return StampGetDto.fromEntities(stamps);
     }
 
-    /** 축제 id로 스탬프 조회 */
     @Transactional(readOnly = true)
     public List<StampGetDto> getStampByFestivalId(Long festivalId) {
         Festival festival = loadFestivalOrThrow(festivalId);
         List<Stamp> stamps = stampRepository.findByFestival(festival);
-        return StampGetDto.fromStampList(stamps);
+        return StampGetDto.fromEntities(stamps);
     }
 
-    /** 스탬프 상태 변경 */
     @Transactional
     public void updateStampOn(Long stampId) {
         Stamp stamp = loadStampOrThrow(stampId);
         stamp.switchStampOn();
     }
 
-    /** 스탬프 삭제 */
     @Transactional
     public void deleteStamp(Long stampId) {
         Stamp stamp = loadStampOrThrow(stampId);
         stampRepository.delete(stamp);
     }
 
-    /** 미션 생성 */
     @Transactional
     public void createMission(Long stampId, MissionSetListDto dto) {
         Stamp stamp = loadStampOrThrow(stampId);
@@ -67,18 +62,15 @@ public class StampService {
         missionRepository.saveAll(missions);
     }
 
-    /** 미션 리스트 조회 */
     @Transactional(readOnly = true)
     public List<MissionSummaryGetDto> getMissions(Long stampId) {
         Stamp stamp = loadStampOrThrow(stampId);
-        return MissionSummaryGetDto.fromMissionList(stamp.getMissions());
+        return MissionSummaryGetDto.fromEntities(stamp.getMissions());
     }
 
-    /** 해당 스탬프 유저들 조회 */
     @Transactional(readOnly = true)
     public List<StampUsersGetDto> getStampUsers(Long stampId) {
         Stamp stamp = loadStampOrThrow(stampId);
-        // return StampUsersGetDto.fromList(stamp.getStampUsers());
         return stamp.getStampUsers()
                 .stream()
                 .map(user -> new StampUsersGetDto(
@@ -91,18 +83,6 @@ public class StampService {
                 .collect(Collectors.toList());
     }
 
-    /** 모든 미션 완료한 사용자 조회 */
-    public List<FinishedStampUserDto> getFinishedStampUsers(Long stampId) {
-        Stamp stamp = loadStampOrThrow(stampId);
-        List<FinishedStampUserDto> finishedUser = stamp.getStampUsers().stream()
-                .filter(StampUser::isFinished)
-                .map(user -> new FinishedStampUserDto(user.getCustom() != null ? user.getCustom().getSchoolNo() : "X", encryptService.decryptInfo(user.getName()), encryptService.decryptInfo(user.getPhone())))
-                .collect(Collectors.toList());
-
-        return finishedUser;
-    }
-
-    /** 미션 성공 기준 정하기 */
     @Transactional
     public void setFinishCnt(Long stampId, Integer cnt) {
         Stamp stamp = loadStampOrThrow(stampId);

--- a/src/main/java/com/halo/eventer/domain/stamp/service/StampUserService.java
+++ b/src/main/java/com/halo/eventer/domain/stamp/service/StampUserService.java
@@ -8,10 +8,11 @@ import com.halo.eventer.domain.stamp.dto.stampUser.*;
 import com.halo.eventer.domain.stamp.exception.*;
 import com.halo.eventer.domain.stamp.repository.StampRepository;
 import com.halo.eventer.domain.stamp.repository.StampUserRepository;
-import com.halo.eventer.global.error.ErrorCode;
-import com.halo.eventer.global.error.exception.BaseException;
+
 import java.util.List;
 import java.util.stream.Collectors;
+
+import com.halo.eventer.global.utils.EncryptService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/src/main/java/com/halo/eventer/global/utils/EncryptService.java
+++ b/src/main/java/com/halo/eventer/global/utils/EncryptService.java
@@ -1,15 +1,15 @@
-package com.halo.eventer.domain.stamp.service;
+package com.halo.eventer.global.utils;
 
 import com.halo.eventer.global.error.ErrorCode;
 import com.halo.eventer.global.error.exception.BaseException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.encrypt.AesBytesEncryptor;
-import org.springframework.stereotype.Service;
+import org.springframework.stereotype.Component;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 
-@Service
+@Component
 @RequiredArgsConstructor
 public class EncryptService {
   private final AesBytesEncryptor aesBytesEncryptor;

--- a/src/test/java/com/halo/eventer/domain/stamp/controller/StampControllerTest.java
+++ b/src/test/java/com/halo/eventer/domain/stamp/controller/StampControllerTest.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.halo.eventer.domain.festival.Festival;
 import com.halo.eventer.domain.festival.dto.FestivalCreateDto;
 import com.halo.eventer.domain.stamp.Stamp;
-import com.halo.eventer.global.security.WithMockPrincipalDetails;
+import com.halo.eventer.global.security.WithMockCustomUserDetails;
 import com.halo.eventer.domain.stamp.dto.stamp.*;
 import com.halo.eventer.domain.stamp.service.StampService;
 import com.halo.eventer.global.config.TestSecurityBeans;
@@ -55,7 +55,7 @@ public class StampControllerTest {
     }
 
     @Test
-    @WithMockPrincipalDetails(roles = "ADMIN")
+    @WithMockCustomUserDetails(roles = "ADMIN")
     void 스탬프_생성_성공() throws Exception {
         given(stampService.registerStamp(anyLong()))
                 .willReturn(List.of(StampGetDto.from(stamp)));
@@ -76,7 +76,7 @@ public class StampControllerTest {
     }
 
     @Test
-    @WithMockPrincipalDetails(roles = "ADMIN")
+    @WithMockCustomUserDetails(roles = "ADMIN")
     void 스탬프_상태변경_성공() throws Exception {
         mockMvc.perform(patch("/stamp")
                         .header("Authorization", ADMIN_TOKEN)
@@ -86,7 +86,7 @@ public class StampControllerTest {
     }
 
     @Test
-    @WithMockPrincipalDetails(roles = "ADMIN")
+    @WithMockCustomUserDetails(roles = "ADMIN")
     void 스탬프_삭제_성공() throws Exception {
         mockMvc.perform(delete("/stamp")
                         .header("Authorization", ADMIN_TOKEN)
@@ -96,7 +96,7 @@ public class StampControllerTest {
     }
 
     @Test
-    @WithMockPrincipalDetails(roles = "ADMIN")
+    @WithMockCustomUserDetails(roles = "ADMIN")
     void 미션_생성_성공() throws Exception {
         MissionSetListDto dto = new MissionSetListDto();
         mockMvc.perform(post("/stamp/mission")
@@ -130,7 +130,7 @@ public class StampControllerTest {
     }
 
     @Test
-    @WithMockPrincipalDetails(roles = "ADMIN")
+    @WithMockCustomUserDetails(roles = "ADMIN")
     void 완료_기준_설정_성공() throws Exception {
         mockMvc.perform(post("/stamp/finishCnt")
                         .header("Authorization", ADMIN_TOKEN)

--- a/src/test/java/com/halo/eventer/domain/stamp/controller/StampControllerTest.java
+++ b/src/test/java/com/halo/eventer/domain/stamp/controller/StampControllerTest.java
@@ -1,0 +1,134 @@
+package com.halo.eventer.domain.stamp.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.halo.eventer.domain.festival.Festival;
+import com.halo.eventer.domain.festival.dto.FestivalCreateDto;
+import com.halo.eventer.domain.stamp.Stamp;
+import com.halo.eventer.domain.stamp.dto.stamp.*;
+import com.halo.eventer.domain.stamp.service.StampService;
+import com.halo.eventer.global.error.GlobalExceptionHandler;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(controllers = StampController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@ExtendWith(MockitoExtension.class)
+public class StampControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private StampService stampService;
+
+    private Stamp stamp;
+
+    @BeforeEach
+    void setUp() {
+        stamp = Stamp.create(Festival.from(
+                new FestivalCreateDto("test festival","test")
+        ));
+        this.mockMvc = MockMvcBuilders
+                .standaloneSetup(new StampController(stampService))
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .build();
+    }
+
+    @Test
+    void 스탬프_생성_성공() throws Exception {
+        given(stampService.registerStamp(anyLong()))
+                .willReturn(List.of(StampGetDto.from(stamp)));
+
+        mockMvc.perform(post("/stamp")
+                        .param("festivalId", "1"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void 스탬프_조회_성공() throws Exception {
+        given(stampService.getStampByFestivalId(anyLong()))
+                .willReturn(List.of(StampGetDto.from(stamp)));
+
+        mockMvc.perform(get("/stamp")
+                        .param("festivalId", "1"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void 스탬프_상태변경_성공() throws Exception {
+        mockMvc.perform(patch("/stamp")
+                        .param("stampId", "1"))
+                .andExpect(status().isOk());
+        then(stampService).should().updateStampOn(1L);
+    }
+
+    @Test
+    void 스탬프_삭제_성공() throws Exception {
+        mockMvc.perform(delete("/stamp")
+                        .param("stampId", "1"))
+                .andExpect(status().isOk());
+        then(stampService).should().deleteStamp(1L);
+    }
+
+    @Test
+    void 미션_생성_성공() throws Exception {
+        MissionSetListDto dto = new MissionSetListDto();
+        mockMvc.perform(post("/stamp/mission")
+                        .param("stampId", "1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(new ObjectMapper().writeValueAsString(dto)))
+                .andExpect(status().isOk());
+        then(stampService).should().createMission(anyLong(), any());
+    }
+
+    @Test
+    void 미션_리스트_조회_성공() throws Exception {
+        given(stampService.getMissions(anyLong()))
+                .willReturn(List.of(new MissionSummaryGetDto()));
+
+        mockMvc.perform(get("/stamp/missions")
+                        .param("stampId", "1"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void 유저_리스트_조회_성공() throws Exception {
+        given(stampService.getStampUsers(anyLong()))
+                .willReturn(List.of(new StampUsersGetDto()));
+
+        mockMvc.perform(get("/stamp/users")
+                        .param("stampId", "1"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void 완료_기준_설정_성공() throws Exception {
+        mockMvc.perform(post("/stamp/finishCnt")
+                        .param("stampId", "1")
+                        .param("cnt", "3"))
+                .andExpect(status().isOk());
+        then(stampService).should().setFinishCnt(1L, 3);
+    }
+}

--- a/src/test/java/com/halo/eventer/domain/stamp/controller/StampControllerTest.java
+++ b/src/test/java/com/halo/eventer/domain/stamp/controller/StampControllerTest.java
@@ -3,33 +3,23 @@ package com.halo.eventer.domain.stamp.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.halo.eventer.domain.festival.Festival;
 import com.halo.eventer.domain.festival.dto.FestivalCreateDto;
-import com.halo.eventer.domain.member.Member;
 import com.halo.eventer.domain.stamp.Stamp;
+import com.halo.eventer.global.security.WithMockPrincipalDetails;
 import com.halo.eventer.domain.stamp.dto.stamp.*;
 import com.halo.eventer.domain.stamp.service.StampService;
 import com.halo.eventer.global.config.TestSecurityBeans;
 import com.halo.eventer.global.config.security.SecurityConfig;
-import com.halo.eventer.global.error.GlobalExceptionHandler;
-import com.halo.eventer.global.security.CustomUserDetails;
 import com.halo.eventer.global.security.provider.JwtProvider;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
-import java.util.Collections;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.*;
@@ -38,11 +28,9 @@ import static org.mockito.BDDMockito.then;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-@WebMvcTest(controllers = StampController.class)
-@ExtendWith(MockitoExtension.class)
-@AutoConfigureMockMvc
 @SuppressWarnings("NonAsciiCharacters")
 @ActiveProfiles("test")
+@WebMvcTest(controllers = StampController.class)
 @Import({TestSecurityBeans.class, SecurityConfig.class})
 public class StampControllerTest {
 
@@ -64,16 +52,10 @@ public class StampControllerTest {
         stamp = Stamp.create(Festival.from(
                 new FestivalCreateDto("test festival","test")
         ));
-        CustomUserDetails customUserDetails = new CustomUserDetails(new Member("admin", "1234"));
-        UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(
-                customUserDetails,
-                null,
-                Collections.singleton(new SimpleGrantedAuthority("ROLE_ADMIN"))
-        );
-        SecurityContextHolder.getContext().setAuthentication(auth);
     }
 
     @Test
+    @WithMockPrincipalDetails(roles = "ADMIN")
     void 스탬프_생성_성공() throws Exception {
         given(stampService.registerStamp(anyLong()))
                 .willReturn(List.of(StampGetDto.from(stamp)));
@@ -94,6 +76,7 @@ public class StampControllerTest {
     }
 
     @Test
+    @WithMockPrincipalDetails(roles = "ADMIN")
     void 스탬프_상태변경_성공() throws Exception {
         mockMvc.perform(patch("/stamp")
                         .header("Authorization", ADMIN_TOKEN)
@@ -103,6 +86,7 @@ public class StampControllerTest {
     }
 
     @Test
+    @WithMockPrincipalDetails(roles = "ADMIN")
     void 스탬프_삭제_성공() throws Exception {
         mockMvc.perform(delete("/stamp")
                         .header("Authorization", ADMIN_TOKEN)
@@ -112,6 +96,7 @@ public class StampControllerTest {
     }
 
     @Test
+    @WithMockPrincipalDetails(roles = "ADMIN")
     void 미션_생성_성공() throws Exception {
         MissionSetListDto dto = new MissionSetListDto();
         mockMvc.perform(post("/stamp/mission")
@@ -134,6 +119,7 @@ public class StampControllerTest {
     }
 
     @Test
+    @WithMockPrincipalDetails(roles = "ADMIN")
     void 유저_리스트_조회_성공() throws Exception {
         given(stampService.getStampUsers(anyLong()))
                 .willReturn(List.of(new StampUsersGetDto()));
@@ -144,6 +130,7 @@ public class StampControllerTest {
     }
 
     @Test
+    @WithMockPrincipalDetails(roles = "ADMIN")
     void 완료_기준_설정_성공() throws Exception {
         mockMvc.perform(post("/stamp/finishCnt")
                         .header("Authorization", ADMIN_TOKEN)

--- a/src/test/java/com/halo/eventer/domain/stamp/controller/StampControllerTest.java
+++ b/src/test/java/com/halo/eventer/domain/stamp/controller/StampControllerTest.java
@@ -3,38 +3,47 @@ package com.halo.eventer.domain.stamp.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.halo.eventer.domain.festival.Festival;
 import com.halo.eventer.domain.festival.dto.FestivalCreateDto;
+import com.halo.eventer.domain.member.Member;
 import com.halo.eventer.domain.stamp.Stamp;
 import com.halo.eventer.domain.stamp.dto.stamp.*;
 import com.halo.eventer.domain.stamp.service.StampService;
+import com.halo.eventer.global.config.TestSecurityBeans;
+import com.halo.eventer.global.config.security.SecurityConfig;
 import com.halo.eventer.global.error.GlobalExceptionHandler;
+import com.halo.eventer.global.security.CustomUserDetails;
+import com.halo.eventer.global.security.provider.JwtProvider;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
+import java.util.Collections;
 import java.util.List;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.hamcrest.Matchers.containsString;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
-import static org.mockito.Mockito.*;
-import static org.springframework.test.util.ReflectionTestUtils.setField;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(controllers = StampController.class)
-@AutoConfigureMockMvc(addFilters = false)
 @ExtendWith(MockitoExtension.class)
+@AutoConfigureMockMvc
+@SuppressWarnings("NonAsciiCharacters")
+@ActiveProfiles("test")
+@Import({TestSecurityBeans.class, SecurityConfig.class})
 public class StampControllerTest {
 
     @Autowired
@@ -43,17 +52,25 @@ public class StampControllerTest {
     @MockBean
     private StampService stampService;
 
+    @MockBean
+    private JwtProvider jwtProvider;
+
     private Stamp stamp;
+
+    private final String ADMIN_TOKEN = "Bearer admin-token";
 
     @BeforeEach
     void setUp() {
         stamp = Stamp.create(Festival.from(
                 new FestivalCreateDto("test festival","test")
         ));
-        this.mockMvc = MockMvcBuilders
-                .standaloneSetup(new StampController(stampService))
-                .setControllerAdvice(new GlobalExceptionHandler())
-                .build();
+        CustomUserDetails customUserDetails = new CustomUserDetails(new Member("admin", "1234"));
+        UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(
+                customUserDetails,
+                null,
+                Collections.singleton(new SimpleGrantedAuthority("ROLE_ADMIN"))
+        );
+        SecurityContextHolder.getContext().setAuthentication(auth);
     }
 
     @Test
@@ -79,6 +96,7 @@ public class StampControllerTest {
     @Test
     void 스탬프_상태변경_성공() throws Exception {
         mockMvc.perform(patch("/stamp")
+                        .header("Authorization", ADMIN_TOKEN)
                         .param("stampId", "1"))
                 .andExpect(status().isOk());
         then(stampService).should().updateStampOn(1L);
@@ -87,6 +105,7 @@ public class StampControllerTest {
     @Test
     void 스탬프_삭제_성공() throws Exception {
         mockMvc.perform(delete("/stamp")
+                        .header("Authorization", ADMIN_TOKEN)
                         .param("stampId", "1"))
                 .andExpect(status().isOk());
         then(stampService).should().deleteStamp(1L);
@@ -96,6 +115,7 @@ public class StampControllerTest {
     void 미션_생성_성공() throws Exception {
         MissionSetListDto dto = new MissionSetListDto();
         mockMvc.perform(post("/stamp/mission")
+                        .header("Authorization", ADMIN_TOKEN)
                         .param("stampId", "1")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(new ObjectMapper().writeValueAsString(dto)))
@@ -126,6 +146,7 @@ public class StampControllerTest {
     @Test
     void 완료_기준_설정_성공() throws Exception {
         mockMvc.perform(post("/stamp/finishCnt")
+                        .header("Authorization", ADMIN_TOKEN)
                         .param("stampId", "1")
                         .param("cnt", "3"))
                 .andExpect(status().isOk());

--- a/src/test/java/com/halo/eventer/domain/stamp/controller/StampControllerTest.java
+++ b/src/test/java/com/halo/eventer/domain/stamp/controller/StampControllerTest.java
@@ -119,7 +119,6 @@ public class StampControllerTest {
     }
 
     @Test
-    @WithMockPrincipalDetails(roles = "ADMIN")
     void 유저_리스트_조회_성공() throws Exception {
         given(stampService.getStampUsers(anyLong()))
                 .willReturn(List.of(new StampUsersGetDto()));

--- a/src/test/java/com/halo/eventer/domain/stamp/service/StampServiceTest.java
+++ b/src/test/java/com/halo/eventer/domain/stamp/service/StampServiceTest.java
@@ -12,6 +12,7 @@ import com.halo.eventer.domain.stamp.exception.StampClosedException;
 import com.halo.eventer.domain.stamp.exception.StampNotFoundException;
 import com.halo.eventer.domain.stamp.repository.MissionRepository;
 import com.halo.eventer.domain.stamp.repository.StampRepository;
+import com.halo.eventer.global.utils.EncryptService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/src/test/java/com/halo/eventer/domain/stamp/service/StampServiceTest.java
+++ b/src/test/java/com/halo/eventer/domain/stamp/service/StampServiceTest.java
@@ -1,0 +1,278 @@
+package com.halo.eventer.domain.stamp.service;
+
+import com.halo.eventer.domain.festival.Festival;
+import com.halo.eventer.domain.festival.dto.FestivalCreateDto;
+import com.halo.eventer.domain.festival.exception.FestivalNotFoundException;
+import com.halo.eventer.domain.festival.repository.FestivalRepository;
+import com.halo.eventer.domain.stamp.Mission;
+import com.halo.eventer.domain.stamp.Stamp;
+import com.halo.eventer.domain.stamp.StampUser;
+import com.halo.eventer.domain.stamp.dto.stamp.*;
+import com.halo.eventer.domain.stamp.exception.StampClosedException;
+import com.halo.eventer.domain.stamp.exception.StampNotFoundException;
+import com.halo.eventer.domain.stamp.repository.MissionRepository;
+import com.halo.eventer.domain.stamp.repository.StampRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+
+@ExtendWith(MockitoExtension.class)
+@ActiveProfiles("test")
+@SuppressWarnings("NonAsciiCharacters")
+public class StampServiceTest {
+
+    @Mock
+    private StampRepository stampRepository;
+
+    @Mock
+    private FestivalRepository festivalRepository;
+
+    @Mock
+    private EncryptService encryptService;
+
+    @Mock
+    private MissionRepository missionRepository;
+
+    @InjectMocks
+    private StampService stampService;
+
+    private Festival festival;
+    private FestivalCreateDto festivalCreateDto;
+    private Stamp stamp;
+    private MissionSetListDto missionSetListDto;
+    private List<MissionSetDto> missionSetDtos;
+
+    @BeforeEach
+    void setUp() {
+        festivalCreateDto = new FestivalCreateDto("test festival","test");
+        festival = Festival.from(festivalCreateDto);
+        stamp = Stamp.create(festival);
+        missionSetListDto = new MissionSetListDto();
+        missionSetDtos = setupMissionSetDtos();
+        setField(missionSetListDto, "missionSets", missionSetDtos);
+    }
+
+    @Test
+    void 축제id로_스탬프_생성_성공(){
+        //given
+        given(festivalRepository.findById(anyLong())).willReturn(Optional.ofNullable(festival));
+        given(stampRepository.save(any(Stamp.class))).willReturn(stamp);
+        List<Stamp> stamps = List.of(stamp);
+        given(stampRepository.findByFestival(festival)).willReturn(stamps);
+
+        // when
+        List<StampGetDto> result = stampService.registerStamp(1L);
+
+        // then
+        assertThat(result).hasSize(1);
+    }
+
+    @Test
+    void 축제id로_스탬프_생성_실패() {
+        // given
+        long notExistFestivalId = 999L;
+        given(festivalRepository.findById(notExistFestivalId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> stampService.registerStamp(notExistFestivalId))
+                .isInstanceOf(FestivalNotFoundException.class);
+    }
+
+    @Test
+    void 축제_id로_스탬프_조회_성공(){
+        given(festivalRepository.findById(anyLong())).willReturn(Optional.ofNullable(festival));
+        List<Stamp> stamps = List.of(Stamp.create(festival));
+        given(stampRepository.findByFestival(festival)).willReturn(stamps);
+
+        // when
+        List<StampGetDto> result = stampService.getStampByFestivalId(1L);
+
+        // then
+        assertThat(result).hasSize(1);
+    }
+
+    @Test
+    void 축제_id로_스탬프_조회_실패(){
+        // given
+        given(festivalRepository.findById(anyLong())).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> stampService.getStampByFestivalId(anyLong()))
+                .isInstanceOf(FestivalNotFoundException.class);
+    }
+
+    @Test
+    void 스탬프_상태_변경_성공(){
+        //given
+        stamp.switchStampOn();
+        given(stampRepository.findById(anyLong())).willReturn(Optional.ofNullable(stamp));
+
+        //when
+        stampService.updateStampOn(1L);
+
+        //then
+        assertThat(stamp.isStampOn()).isTrue();
+    }
+
+    @Test
+    void 스탬프_상태_변경_실패(){
+        // given
+        given(stampRepository.findById(anyLong())).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> stampService.updateStampOn(anyLong()))
+                .isInstanceOf(StampNotFoundException.class);
+    }
+
+    @Test
+    void 스탬프_삭제_성공(){
+        //given
+        given(stampRepository.findById(anyLong())).willReturn(Optional.of(stamp));
+
+        //when
+        stampService.deleteStamp(1L);
+
+        //then
+        verify(stampRepository, times(1)).delete(stamp);
+    }
+
+    @Test
+    void 미션_생성_성공(){
+        //given
+        given(stampRepository.findById(anyLong())).willReturn(Optional.of(stamp));
+
+        //when
+        stampService.createMission(1L, missionSetListDto);
+
+        // then
+        verify(missionRepository, times(1)).saveAll(anyList());
+    }
+
+    @Test
+    void 미션_생성_실패(){
+        //given
+        stamp.switchStampOn();
+        given(stampRepository.findById(anyLong())).willReturn(Optional.of(stamp));
+
+        //when & then
+        assertThatThrownBy(() -> stampService.createMission(anyLong(), missionSetListDto))
+                .isInstanceOf(StampClosedException.class);
+    }
+
+    @Test
+    void 미션_리스트_조회_성공(){
+        //given
+        Mission mission1 = setUpMission(1L, "미션1");
+        Mission mission2 = setUpMission(2L, "미션2");
+        mission1.addStamp(stamp);
+        mission2.addStamp(stamp);
+        given(stampRepository.findById(anyLong())).willReturn(Optional.of(stamp));
+
+        // when
+        List<MissionSummaryGetDto> result = stampService.getMissions(1L);
+
+        // then
+        assertThat(result).hasSize(2);
+        assertThat(result)
+                .extracting("title")
+                .containsExactly("미션1", "미션2");
+    }
+
+    @Test
+    void 미션_리스트_조회_실패(){
+        // given
+        given(stampRepository.findById(anyLong())).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> stampService.getMissions(anyLong()))
+                .isInstanceOf(StampNotFoundException.class);
+    }
+
+    @Test
+    void 해당_스탬프_유저들_조회_성공(){
+        //given
+        StampUser stampUser1 =
+                new StampUser(stamp, "암호화번호1", "암호화이름1", 1);
+        stamp.getStampUsers().add(stampUser1);
+        given(stampRepository.findById(anyLong())).willReturn(Optional.ofNullable(stamp));
+        given(encryptService.decryptInfo(anyString())).willReturn("암호화");
+
+        //when
+        List<StampUsersGetDto> result = stampService.getStampUsers(1L);
+
+        //then
+        assertThat(result).hasSize(1);
+        assertThat(result)
+                .extracting("name")
+                .containsExactly("암호화");
+    }
+
+    @Test
+    void 미션성공_기준_정하기_성공() {
+        // given
+        Integer finishCnt = 5;
+        given(stampRepository.findById(1L)).willReturn(Optional.of(stamp));
+
+        // when
+        stampService.setFinishCnt(1L, finishCnt);
+
+        // then
+        assertThat(stamp.getStampFinishCnt()).isEqualTo(finishCnt);
+    }
+
+    @Test
+    void 미션성공_기준_정하기_실패() {
+        // given
+        given(stampRepository.findById(1L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> stampService.setFinishCnt(1L, 3))
+                .isInstanceOf(StampNotFoundException.class);
+    }
+
+    private Mission setUpMission(Long id, String missionTitle){
+        Mission mission = new Mission();
+        setField(mission, "id", id);
+        setField(mission, "title", missionTitle);
+        return mission;
+    }
+
+    private List<MissionSetDto> setupMissionSetDtos() {
+        return List.of(
+                new MissionSetDto(
+                        1L,
+                        "부스 A",
+                        "미션 내용 A",
+                        "장소 A",
+                        "오전 10시",
+                        "clearedA.png",
+                        "notClearedA.png"
+                ),
+                new MissionSetDto(
+                        2L,
+                        "부스 B",
+                        "미션 내용 B",
+                        "장소 B",
+                        "오전 11시",
+                        "clearedB.png",
+                        "notClearedB.png"
+                )
+        );
+    }
+}

--- a/src/test/java/com/halo/eventer/global/security/WithMockCustomUserDetails.java
+++ b/src/test/java/com/halo/eventer/global/security/WithMockCustomUserDetails.java
@@ -7,7 +7,7 @@ import java.lang.annotation.RetentionPolicy;
 
 @Retention(RetentionPolicy.RUNTIME)
 @WithSecurityContext(factory = WithMockPrincipalDetailsSecurityContextFactory.class)
-public @interface WithMockPrincipalDetails {
+public @interface WithMockCustomUserDetails {
     long id() default 1L;
     String[] roles() default {"ADMIN"};
 }

--- a/src/test/java/com/halo/eventer/global/security/WithMockPrincipalDetails.java
+++ b/src/test/java/com/halo/eventer/global/security/WithMockPrincipalDetails.java
@@ -1,0 +1,13 @@
+package com.halo.eventer.global.security;
+
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+@WithSecurityContext(factory = WithMockPrincipalDetailsSecurityContextFactory.class)
+public @interface WithMockPrincipalDetails {
+    long id() default 1L;
+    String[] roles() default {"ADMIN"};
+}

--- a/src/test/java/com/halo/eventer/global/security/WithMockPrincipalDetailsSecurityContextFactory.java
+++ b/src/test/java/com/halo/eventer/global/security/WithMockPrincipalDetailsSecurityContextFactory.java
@@ -1,0 +1,37 @@
+package com.halo.eventer.global.security;
+
+import com.halo.eventer.domain.member.Member;
+import org.mockito.Mockito;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+public class WithMockPrincipalDetailsSecurityContextFactory
+        implements WithSecurityContextFactory<WithMockPrincipalDetails> {
+
+    @Override
+    public SecurityContext createSecurityContext(WithMockPrincipalDetails annotation) {
+
+        CustomUserDetails customUserDetails = Mockito.mock(CustomUserDetails.class);
+        Member member = Mockito.mock(Member.class);
+
+        Mockito.when(member.getId()).thenReturn(annotation.id());
+        Mockito.when(member.getLoginId()).thenReturn("admin");
+
+        UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(
+                customUserDetails,
+                null,
+                Collections.singleton(new SimpleGrantedAuthority("ROLE_" + Arrays.toString(annotation.roles())))
+        );
+
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+        context.setAuthentication(auth);
+        SecurityContextHolder.setContext(context);
+        return context;
+    }
+}

--- a/src/test/java/com/halo/eventer/global/security/WithMockPrincipalDetailsSecurityContextFactory.java
+++ b/src/test/java/com/halo/eventer/global/security/WithMockPrincipalDetailsSecurityContextFactory.java
@@ -12,10 +12,10 @@ import java.util.Arrays;
 import java.util.Collections;
 
 public class WithMockPrincipalDetailsSecurityContextFactory
-        implements WithSecurityContextFactory<WithMockPrincipalDetails> {
+        implements WithSecurityContextFactory<WithMockCustomUserDetails> {
 
     @Override
-    public SecurityContext createSecurityContext(WithMockPrincipalDetails annotation) {
+    public SecurityContext createSecurityContext(WithMockCustomUserDetails annotation) {
 
         CustomUserDetails customUserDetails = Mockito.mock(CustomUserDetails.class);
         Member member = Mockito.mock(Member.class);


### PR DESCRIPTION
## #️⃣연관된 이슈

- #103 
## 📝작업 내용

1. StampService, StampController 테스트 코드 작성
2. StampService, StampController 리펙토링

## 💬리뷰 요구사항

### EncryptService
```
@Transactional(readOnly = true)
    public List<StampUsersGetDto> getStampUsers(Long stampId) {
        Stamp stamp = loadStampOrThrow(stampId);
        return stamp.getStampUsers()
                .stream()
                .map(user -> new StampUsersGetDto(
                        user.getUuid(),
                        encryptService.decryptInfo(user.getName()),
                        encryptService.decryptInfo(user.getPhone()),
                        user.isFinished(),
                        user.getParticipantCount()
                ))
                .collect(Collectors.toList());
    }
```
현재 암호화/복호화 클래스인 encryptService는 도메인과 무관한 기능이므로, 예를 들어 global의 utils 디렉토리로 이동시키는 것이 어떨까 생각이 듭니다.

### 쓰이지 않은 메서드에 대해
```
 public List<FinishedStampUserDto> getFinishedStampUsers(Long stampId) {
        Stamp stamp = loadStampOrThrow(stampId);
        List<FinishedStampUserDto> finishedUser = stamp.getStampUsers().stream()
                .filter(StampUser::isFinished)
                .map(user -> new FinishedStampUserDto(user.getCustom() != null ? user.getCustom().getSchoolNo() : "X", encryptService.decryptInfo(user.getName()), encryptService.decryptInfo(user.getPhone())))
                .collect(Collectors.toList());

        return finishedUser;
    }
```
위 Service 메서드는 쓰이지 않고 있는데, 정의한 특별한 이유가 있나요?

### Response DTO
```
@Getter
@NoArgsConstructor
@AllArgsConstructor
public class StampUsersGetDto {
...
  public static List<StampUsersGetDto> fromList(List<StampUser> stampUsers){
    return stampUsers.stream()
            .map(StampUsersGetDto::from)
            .collect(Collectors.toList());
  }

  public static StampUsersGetDto from(StampUser stampUser){
    return new StampUsersGetDto(
            stampUser.getUuid(),
            stampUser.getName(),
            stampUser.getPhone(),
            stampUser.isFinished(),
            stampUser.getParticipantCount()
    );
  }
}

```
기존 Service 클래스의 메서드안에서 실행하던 스트림을 모두 Dto로 옮겼고, entity->dto 변환 정적 팩토리 메서드도 생성했습니다.
1. 빌더 패턴을 모두 적용할까요?
2. 스트림을 모두 Dto에 정의하는 것이 맞을까요?

### 연관관계 매핑
```
    private Stamp(Festival festival){
        this.festival = festival;
        festival.getStamps().add(this);
    }

    public static Stamp create(Festival festival){
        return new Stamp(festival);
    }
```
기존에 짜여진 로직을 보아하니, Stamp는 Festival이 존재해야지만 새로운 인스턴스를 만들 수 있습니다. 엔티티에 대한 정적 팩토리 메서드 정의 시 연관관계 있는 엔티티를 argument로 넣어 직접 연관관계를 설정했습니다. 연관관계 설정 메서드는 다 대 일 관계에선 다 쪽에만 정의했습니다. 

위 내용들에 대한 @HeeChanN 님의 의견이 궁금합니다.
의견을 받은 후 수정하도록 하겠습니다.