### PR TITLE
[test] : InquiryController 테스트 코드 작성 및 테스트 설정 파일 수정

### DIFF
--- a/src/main/java/com/halo/eventer/domain/inquiry/controller/InquiryController.java
+++ b/src/main/java/com/halo/eventer/domain/inquiry/controller/InquiryController.java
@@ -1,7 +1,5 @@
 package com.halo.eventer.domain.inquiry.controller;
 
-
-
 import com.halo.eventer.domain.inquiry.dto.*;
 import com.halo.eventer.domain.inquiry.service.InquiryService;
 import javax.validation.constraints.Min;
@@ -17,7 +15,7 @@ public class InquiryController {
 
     @PostMapping
     public void create(@RequestParam("festivalId") Long festivalId ,
-                                @RequestBody InquiryCreateReqDto inquiryCreateReqDto){
+                       @RequestBody InquiryCreateReqDto inquiryCreateReqDto){
         inquiryService.create(festivalId,inquiryCreateReqDto);
     }
 
@@ -29,13 +27,13 @@ public class InquiryController {
 
     @GetMapping("/forAdmin/{inquiryId}")
     public InquiryResDto getInquiryForAdmin(@PathVariable("inquiryId") Long id){
-        return new InquiryResDto(inquiryService.findInquiryForAdmin(id));
+        return inquiryService.findInquiryForAdmin(id);
     }
 
     @PatchMapping("/forAdmin")
-    public InquiryResDto updateInquiryAnswer(@RequestParam("inquiryId") Long id,
+    public InquiryResDto updateInquiryAnswer(@RequestParam("inquiryId") Long inquiryId,
                                        @RequestBody InquiryAnswerReqDto answerReqDto){
-        return new InquiryResDto(inquiryService.updateInquiryAnswer(id, answerReqDto));
+        return inquiryService.updateInquiryAnswer(inquiryId, answerReqDto);
     }
 
     @DeleteMapping("/forAdmin")

--- a/src/main/java/com/halo/eventer/domain/inquiry/controller/InquiryController.java
+++ b/src/main/java/com/halo/eventer/domain/inquiry/controller/InquiryController.java
@@ -8,12 +8,10 @@ import javax.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
-
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/inquiry")
-public class inquiryController {
+public class InquiryController {
 
     private final InquiryService inquiryService;
 

--- a/src/main/java/com/halo/eventer/domain/inquiry/dto/InquiryNoOffsetPageDto.java
+++ b/src/main/java/com/halo/eventer/domain/inquiry/dto/InquiryNoOffsetPageDto.java
@@ -11,15 +11,15 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 public class InquiryNoOffsetPageDto {
-    private List<InquiryItemDto> inquiryList;
+    private List<InquiryItemDto> inquiries;
     private Boolean isLast;
 
     public InquiryNoOffsetPageDto(List<Inquiry> inquiryList, Boolean isLast) {
-        this.inquiryList = inquiryList.stream().map(InquiryItemDto::new).collect(Collectors.toList());
+        this.inquiries = inquiryList.stream().map(InquiryItemDto::new).collect(Collectors.toList());
         this.isLast = isLast;
     }
 
     public void updateInquiryItemDtoWithTitleVisibility() {
-        this.inquiryList.forEach(InquiryItemDto::changeTitleToSecretValue);
+        this.inquiries.forEach(InquiryItemDto::changeTitleToSecretValue);
     }
 }

--- a/src/main/java/com/halo/eventer/domain/inquiry/service/InquiryService.java
+++ b/src/main/java/com/halo/eventer/domain/inquiry/service/InquiryService.java
@@ -36,15 +36,16 @@ public class InquiryService {
     return getInquiriesWithNoOffsetPaging(festivalId,lastId);
   }
 
-  public Inquiry findInquiryForAdmin(Long id) {
-    return inquiryRepository.findById(id).orElseThrow(() -> new InquiryNotFoundException(id));
+  public InquiryResDto findInquiryForAdmin(Long id) {
+    Inquiry inquiry = inquiryRepository.findById(id).orElseThrow(() -> new InquiryNotFoundException(id));
+    return new InquiryResDto(inquiry);
   }
 
   @Transactional
-  public Inquiry updateInquiryAnswer(Long id, InquiryAnswerReqDto dto) {
+  public InquiryResDto updateInquiryAnswer(Long id, InquiryAnswerReqDto dto) {
     Inquiry inquiry = inquiryRepository.findById(id).orElseThrow(() -> new InquiryNotFoundException(id));
     inquiry.registerAnswer(dto.getAnswer());
-    return inquiry;
+    return new InquiryResDto(inquiry);
   }
 
   public void delete(Long id) {

--- a/src/main/java/com/halo/eventer/global/constants/SecurityConstants.java
+++ b/src/main/java/com/halo/eventer/global/constants/SecurityConstants.java
@@ -19,6 +19,7 @@ public class SecurityConstants {
             "/widget/*",
             "/widget",
             "/stamp",
+            "/stamp/users",
             "/stamp/missions",
             "/stamp/mission",
             "/splash",

--- a/src/test/java/com/halo/eventer/domain/inquiry/controller/InquiryControllerTest.java
+++ b/src/test/java/com/halo/eventer/domain/inquiry/controller/InquiryControllerTest.java
@@ -1,0 +1,32 @@
+package com.halo.eventer.domain.inquiry.controller;
+
+
+import com.halo.eventer.domain.inquiry.service.InquiryService;
+import com.halo.eventer.global.config.TestSecurityBeans;
+import com.halo.eventer.global.config.security.SecurityConfig;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(InquiryController.class)
+@AutoConfigureMockMvc
+@SuppressWarnings("NonAsciiCharacters")
+@ActiveProfiles("test")
+@Import({TestSecurityBeans.class, SecurityConfig.class})
+public class InquiryControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Mock
+    private InquiryService inquiryService;
+
+    @InjectMocks
+    private InquiryController inquiryController;
+
+}

--- a/src/test/java/com/halo/eventer/domain/inquiry/controller/InquiryControllerTest.java
+++ b/src/test/java/com/halo/eventer/domain/inquiry/controller/InquiryControllerTest.java
@@ -1,32 +1,255 @@
 package com.halo.eventer.domain.inquiry.controller;
 
-
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.halo.eventer.domain.festival.Festival;
+import com.halo.eventer.domain.inquiry.Inquiry;
+import com.halo.eventer.domain.inquiry.dto.*;
 import com.halo.eventer.domain.inquiry.service.InquiryService;
-import com.halo.eventer.global.config.TestSecurityBeans;
+import com.halo.eventer.global.config.ControllerTestSecurityBeans;
 import com.halo.eventer.global.config.security.SecurityConfig;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
+import com.halo.eventer.global.security.provider.JwtProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(InquiryController.class)
 @AutoConfigureMockMvc
 @SuppressWarnings("NonAsciiCharacters")
 @ActiveProfiles("test")
-@Import({TestSecurityBeans.class, SecurityConfig.class})
+@Import({ControllerTestSecurityBeans.class, SecurityConfig.class})
 public class InquiryControllerTest {
 
-    @Autowired
-    private MockMvc mockMvc;
+  @Autowired private MockMvc mockMvc;
 
-    @Mock
-    private InquiryService inquiryService;
+  @Autowired private ObjectMapper objectMapper;
 
-    @InjectMocks
-    private InquiryController inquiryController;
+  @MockBean private InquiryService inquiryService;
 
+  @MockBean private JwtProvider jwtProvider;
+
+  private final Long festivalId = 1L;
+  private final Long inquiryId = 1L;
+
+  List<Inquiry> inquiryList;
+  Inquiry inquiry;
+  Festival festival;
+  InquiryCreateReqDto inquiryCreateReqDto;
+
+  @BeforeEach
+  void setUp() {
+    inquiryCreateReqDto = new InquiryCreateReqDto("제목", true, "아이디", "1234", "내용");
+    festival = new Festival();
+    inquiry = new Inquiry(festival, inquiryCreateReqDto, "1234");
+    inquiryList = makeInquiryList();
+  }
+
+  @Test
+  void 문의사항_생성() throws Exception {
+    // given
+    doNothing().when(inquiryService).create(festivalId, inquiryCreateReqDto);
+
+    // when & then
+    mockMvc.perform(post("/inquiry")
+                .param("festivalId", "1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(inquiryCreateReqDto)))
+        .andExpect(status().isOk());
+  }
+
+  @Test
+  @WithMockUser(username = "admin", roles = "ADMIN")
+  void 어드민용_문의사항_페이징_조회() throws Exception {
+    // given
+    InquiryNoOffsetPageDto inquiryNoOffsetPageDto = new InquiryNoOffsetPageDto(inquiryList, false);
+    given(inquiryService.getAllInquiryForAdmin(festivalId, 0L)).willReturn(inquiryNoOffsetPageDto);
+
+    // then
+    mockMvc.perform(get("/inquiry/forAdmin")
+                .param("festivalId", "1")
+                .param("lastId", "0")
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.inquiries", hasSize(10)))
+        .andExpect(jsonPath("$.isLast").value(false));
+  }
+
+  @Test
+  @WithMockUser(username = "user", roles = "USER")
+  void 권한이없는_계정으로_문의사항_페이징_조회_인가거부() throws Exception {
+    // given
+    InquiryNoOffsetPageDto inquiryNoOffsetPageDto = new InquiryNoOffsetPageDto(inquiryList, false);
+    given(inquiryService.getAllInquiryForAdmin(festivalId, 0L)).willReturn(inquiryNoOffsetPageDto);
+
+    // then
+    mockMvc.perform(get("/inquiry/forAdmin")
+                .param("festivalId", "1")
+                .param("lastId", "0")
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  void 일반사용자가_어드민용_문의사항_페이징_조회_인증거부() throws Exception {
+    // given
+    InquiryNoOffsetPageDto inquiryNoOffsetPageDto = new InquiryNoOffsetPageDto(inquiryList, false);
+    given(inquiryService.getAllInquiryForAdmin(festivalId, 0L)).willReturn(inquiryNoOffsetPageDto);
+
+    // then
+    mockMvc.perform(get("/inquiry/forAdmin")
+                .param("festivalId", "1")
+                .param("lastId", "0")
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  @WithMockUser(username = "admin", roles = "ADMIN")
+  void 어드민_문의사항_단일조회() throws Exception {
+    // given
+    given(inquiryService.findInquiryForAdmin(inquiryId)).willReturn(new InquiryResDto(inquiry));
+
+    // then
+    mockMvc.perform(get("/inquiry/forAdmin/{inquiryId}", inquiryId).contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.title").value("제목"))
+        .andExpect(jsonPath("$.userId").value("아이디"))
+        .andExpect(jsonPath("$.content").value("내용"));
+  }
+
+  @Test
+  @WithMockUser(username = "user", roles = "USER")
+  void 권한없는_사용자_문의사항_단일조회_인가거부() throws Exception {
+    // given
+    given(inquiryService.findInquiryForAdmin(inquiryId)).willReturn(new InquiryResDto(inquiry));
+
+    // then
+    mockMvc.perform(get("/inquiry/forAdmin/{inquiryId}", inquiryId).contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  void 일반사용자_문의사항_단일조회_인증거부() throws Exception {
+    // given
+    given(inquiryService.findInquiryForAdmin(inquiryId)).willReturn(new InquiryResDto(inquiry));
+
+    // then
+    mockMvc.perform(get("/inquiry/forAdmin/{inquiryId}", inquiryId).contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  @WithMockUser(username = "admin", roles = "ADMIN")
+  void 어드민_문의사항에_답변_달기() throws Exception {
+    // given
+    InquiryAnswerReqDto answerReqDto = new InquiryAnswerReqDto("답변");
+    inquiry.registerAnswer("답변");
+    given(inquiryService.updateInquiryAnswer(any(), any())).willReturn(new InquiryResDto(inquiry));
+
+    // then
+    mockMvc.perform(patch("/inquiry/forAdmin")
+                .param("inquiryId", "1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(answerReqDto)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.answer").value("답변"));
+  }
+
+  @Test
+  @WithMockUser(username = "user", roles = "USER")
+  void 권한없는_유저_문의사항에_답변_달기_인가거부() throws Exception {
+    // given
+    InquiryAnswerReqDto answerReqDto = new InquiryAnswerReqDto("답변");
+    inquiry.registerAnswer("답변");
+    given(inquiryService.updateInquiryAnswer(any(), any())).willReturn(new InquiryResDto(inquiry));
+
+    // then
+    mockMvc.perform(patch("/inquiry/forAdmin")
+                .param("inquiryId", "1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(answerReqDto)))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  @WithMockUser(username = "admin", roles = "ADMIN")
+  void 문의사항_삭제() throws Exception {
+    // given
+    doNothing().when(inquiryService).delete(inquiryId);
+
+    // when & then
+    mockMvc.perform(delete("/inquiry/forAdmin")
+                .param("inquiryId", "1")
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk());
+  }
+
+  @Test
+  @WithMockUser(username = "user", roles = "USER")
+  void 권한없는_유저_문의사항에_삭제_인가거부() throws Exception {
+    // given
+    doNothing().when(inquiryService).delete(inquiryId);
+
+    // when & then
+    mockMvc.perform(delete("/inquiry/forAdmin")
+                .param("inquiryId", "1")
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  void 일반_유저용_문의사항_리스트_조회() throws Exception {
+    // given
+    InquiryNoOffsetPageDto inquiryNoOffsetPageDto = new InquiryNoOffsetPageDto(inquiryList, false);
+    given(inquiryService.getAllInquiryForUser(festivalId, 0L)).willReturn(inquiryNoOffsetPageDto);
+
+    // then
+    mockMvc.perform(get("/inquiry/forUser")
+                .param("festivalId", "1")
+                .param("lastId", "0")
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.inquiries", hasSize(10)))
+        .andExpect(jsonPath("$.isLast").value(false));
+  }
+
+  @Test
+  void 일반유저_비밀글_접근() throws Exception {
+    // given
+    InquiryUserReqDto inquiryUserReqDto = new InquiryUserReqDto("아이디", "비밀번호");
+    given(inquiryService.getInquiryForUser(any(), any())).willReturn(new InquiryResDto(inquiry));
+
+    // then
+    mockMvc.perform(post("/inquiry/forUser/{inquiryId}", inquiryId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(inquiryUserReqDto)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.userId").value("아이디"));
+  }
+
+  private List<Inquiry> makeInquiryList() {
+    List<Inquiry> inquiryItemDtoList = new ArrayList<>();
+    for (int i = 0; i < 10; i++) {
+      inquiryItemDtoList.add(inquiry);
+    }
+    return inquiryItemDtoList;
+  }
 }

--- a/src/test/java/com/halo/eventer/domain/inquiry/service/InquiryServiceTest.java
+++ b/src/test/java/com/halo/eventer/domain/inquiry/service/InquiryServiceTest.java
@@ -95,8 +95,8 @@ public class InquiryServiceTest {
         InquiryNoOffsetPageDto results = inquiryService.getAllInquiryForAdmin(festivalId,0L);
 
         //then
-        assertThat(results.getInquiryList()).hasSize(20);
-        assertThat(results.getInquiryList().get(0))
+        assertThat(results.getInquiries()).hasSize(20);
+        assertThat(results.getInquiries().get(0))
                 .usingRecursiveComparison()
                 .comparingOnlyFields("title","isSecret","isAnswered","userId","content")
                 .isEqualTo(secretInquiry);
@@ -111,7 +111,7 @@ public class InquiryServiceTest {
         InquiryNoOffsetPageDto results = inquiryService.getAllInquiryForAdmin(festivalId,0L);
 
         //then
-        assertThat(results.getInquiryList()).isEmpty();
+        assertThat(results.getInquiries()).isEmpty();
     }
 
     @Test
@@ -120,10 +120,10 @@ public class InquiryServiceTest {
         given(inquiryRepository.findById(inquiryId)).willReturn(Optional.of(secretInquiry));
 
         //when
-        Inquiry result = inquiryService.findInquiryForAdmin(inquiryId);
+        InquiryResDto result = inquiryService.findInquiryForAdmin(inquiryId);
 
         //then
-        assertThat(result).isEqualTo(secretInquiry);
+        assertThat(result.getTitle()).isEqualTo(secretInquiry.getTitle());
     }
 
     @Test
@@ -141,7 +141,7 @@ public class InquiryServiceTest {
         InquiryAnswerReqDto dto = new InquiryAnswerReqDto("답변");
 
         //when
-        Inquiry result = inquiryService.updateInquiryAnswer(inquiryId,dto);
+        InquiryResDto result = inquiryService.updateInquiryAnswer(inquiryId,dto);
 
         //then
         assertThat(result.getAnswer()).isEqualTo(dto.getAnswer());
@@ -166,9 +166,9 @@ public class InquiryServiceTest {
         InquiryNoOffsetPageDto results = inquiryService.getAllInquiryForUser(festivalId,0L);
 
         //then
-        assertThat(results.getInquiryList()).hasSize(2);
-        assertThat(results.getInquiryList().get(0).getTitle()).isEqualTo("HIDDEN");
-        assertThat(results.getInquiryList().get(1).getTitle()).isEqualTo("제목");
+        assertThat(results.getInquiries()).hasSize(2);
+        assertThat(results.getInquiries().get(0).getTitle()).isEqualTo("HIDDEN");
+        assertThat(results.getInquiries().get(1).getTitle()).isEqualTo("제목");
     }
 
     @Test
@@ -209,7 +209,7 @@ public class InquiryServiceTest {
 
         //then
         assertThat(dto).isNotNull();
-        assertThat(dto.getInquiryList().size()).isEqualTo(20);
+        assertThat(dto.getInquiries().size()).isEqualTo(20);
         assertThat(dto.getIsLast()).isTrue();
     }
 
@@ -223,7 +223,7 @@ public class InquiryServiceTest {
 
         //then
         assertThat(dto).isNotNull();
-        assertThat(dto.getInquiryList().size()).isEqualTo(20);
+        assertThat(dto.getInquiries().size()).isEqualTo(20);
         assertThat(dto.getIsLast()).isFalse();
     }
 

--- a/src/test/java/com/halo/eventer/domain/stamp/controller/StampControllerTest.java
+++ b/src/test/java/com/halo/eventer/domain/stamp/controller/StampControllerTest.java
@@ -4,10 +4,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.halo.eventer.domain.festival.Festival;
 import com.halo.eventer.domain.festival.dto.FestivalCreateDto;
 import com.halo.eventer.domain.stamp.Stamp;
+import com.halo.eventer.global.config.ControllerTestSecurityBeans;
 import com.halo.eventer.global.security.WithMockCustomUserDetails;
 import com.halo.eventer.domain.stamp.dto.stamp.*;
 import com.halo.eventer.domain.stamp.service.StampService;
-import com.halo.eventer.global.config.TestSecurityBeans;
 import com.halo.eventer.global.config.security.SecurityConfig;
 import com.halo.eventer.global.security.provider.JwtProvider;
 import org.junit.jupiter.api.BeforeEach;
@@ -17,6 +17,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -31,7 +32,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @SuppressWarnings("NonAsciiCharacters")
 @ActiveProfiles("test")
 @WebMvcTest(controllers = StampController.class)
-@Import({TestSecurityBeans.class, SecurityConfig.class})
+@Import({ControllerTestSecurityBeans.class, SecurityConfig.class})
 public class StampControllerTest {
 
     @Autowired
@@ -55,7 +56,7 @@ public class StampControllerTest {
     }
 
     @Test
-    @WithMockCustomUserDetails(roles = "ADMIN")
+    @WithMockUser(username = "admin", roles = "ADMIN")
     void 스탬프_생성_성공() throws Exception {
         given(stampService.registerStamp(anyLong()))
                 .willReturn(List.of(StampGetDto.from(stamp)));
@@ -76,7 +77,7 @@ public class StampControllerTest {
     }
 
     @Test
-    @WithMockCustomUserDetails(roles = "ADMIN")
+    @WithMockUser(username = "admin", roles = "ADMIN")
     void 스탬프_상태변경_성공() throws Exception {
         mockMvc.perform(patch("/stamp")
                         .header("Authorization", ADMIN_TOKEN)
@@ -86,7 +87,7 @@ public class StampControllerTest {
     }
 
     @Test
-    @WithMockCustomUserDetails(roles = "ADMIN")
+    @WithMockUser(username = "admin", roles = "ADMIN")
     void 스탬프_삭제_성공() throws Exception {
         mockMvc.perform(delete("/stamp")
                         .header("Authorization", ADMIN_TOKEN)
@@ -96,7 +97,7 @@ public class StampControllerTest {
     }
 
     @Test
-    @WithMockCustomUserDetails(roles = "ADMIN")
+    @WithMockUser(username = "admin", roles = "ADMIN")
     void 미션_생성_성공() throws Exception {
         MissionSetListDto dto = new MissionSetListDto();
         mockMvc.perform(post("/stamp/mission")
@@ -129,7 +130,7 @@ public class StampControllerTest {
     }
 
     @Test
-    @WithMockCustomUserDetails(roles = "ADMIN")
+    @WithMockUser(username = "admin", roles = "ADMIN")
     void 완료_기준_설정_성공() throws Exception {
         mockMvc.perform(post("/stamp/finishCnt")
                         .header("Authorization", ADMIN_TOKEN)

--- a/src/test/java/com/halo/eventer/global/config/ControllerTestSecurityBeans.java
+++ b/src/test/java/com/halo/eventer/global/config/ControllerTestSecurityBeans.java
@@ -9,6 +9,7 @@ import com.halo.eventer.global.security.exception.CustomAuthenticationEntryPoint
 import com.halo.eventer.global.security.provider.JwtProvider;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.servlet.HandlerExceptionResolver;
@@ -17,31 +18,17 @@ import org.springframework.web.servlet.HandlerExceptionResolver;
 @TestConfiguration
 public class ControllerTestSecurityBeans {
 
-    // 테스트 전용 CorsConfigurationSource 빈 생성
-    @Bean
+    @MockBean
     @Qualifier("customCorsConfigurationSource")
-    public CorsConfigurationSource corsConfigurationSource() {
-        return new CorsConfig().customCorsConfigurationSource();
-    }
+    private CorsConfigurationSource corsConfigurationSource;
 
+    @Bean
+    public JwtAuthenticationFilterConfig jwtAuthenticationFilterConfig(JwtProvider jwtProvider) {
+        return new JwtAuthenticationFilterConfig(jwtProvider);
+    }
     @Bean
     public AuthorizationConfig authorizationConfig() {
         return new AuthorizationConfig();
-    }
-
-    @Bean
-    public JwtAuthenticationFilterConfig securityFilterConfig(JwtProvider jwtProvider) {
-        return new JwtAuthenticationFilterConfig(jwtProvider);
-    }
-
-    @Bean
-    public CustomAccessDeniedHandler customAccessDeniedHandler() {
-        return new CustomAccessDeniedHandler();
-    }
-
-    @Bean
-    public CustomAuthenticationEntryPoint customAuthenticationEntryPoint(){
-        return new CustomAuthenticationEntryPoint();
     }
 
     @Bean


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #96

## 📝작업 내용

<br>

### InquiryControllerTest 코드 작성 및 바꾼 SecurityConfig에 맞게 설정 변경

Controller 테스트에서 권한검사 까지 하기 위해 ControllerTestSecurityBeans를 이용하여 권한검사에 필요한 Security 빈들을 생성하여 SecurityConfig에 주입하는 방식으로 진행하였습니다.

customAccessDeniedHandler ,customAuthenticationEntryPoint를 제거하였고 CorsConfig같은 경우 실제 테스트할 목표지점이 아니기 떄문에 Mock으로 빈을 생성하였습니다.

또한, 실제 프로젝트에서 사용하는 인증/인가의 경우 SecurityFilterChain의 마지막 부분에 SecurityContext에 들어가 있는 역할 정보를 바탕으로 인증/인가 에러가 발생하기 때문에 JwtAuthenticationFilterConfig의 JwtProvider도 목으로 대체하였습니다.

<br>

### @WithMockUser(username = "admin", roles = "ADMIN") 사용

FestivalControllerTest의 경우 실제 직접 아래와 같이 SecurityContext에 담아주는 코드를 작성하였는데 @WithMockUser 어노테이션이 아래 코드를 대체할 수 있다는 사실을 확인하였고 따라서, InquiryController의 테스트코드에서는 @WithMockUser를 적극적으로 사용하였습니다.

```java
CustomUserDetails customUserDetails = new CustomUserDetails(new Member("admin", "1234"));
UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(customUserDetails, null, 
Collections.singleton(new SimpleGrantedAuthority("ROLE_ADMIN")));
SecurityContextHolder.getContext().setAuthentication(auth);
```


