### PR TITLE
[refactor] : jwt claims로 들어가는 roles 내용 수정

### DIFF
--- a/src/main/java/com/halo/eventer/domain/member/Member.java
+++ b/src/main/java/com/halo/eventer/domain/member/Member.java
@@ -37,7 +37,7 @@ public class Member {
         roles.forEach(o -> o.setMember(this));
     }
 
-    public List<String> getAuthoritiesNames() {
+    public List<String> getRoleNames() {
         return authorities.stream()
                 .map(Authority::getRoleName)
                 .collect(Collectors.toList());

--- a/src/main/java/com/halo/eventer/domain/member/Member.java
+++ b/src/main/java/com/halo/eventer/domain/member/Member.java
@@ -2,6 +2,7 @@ package com.halo.eventer.domain.member;
 
 
 import java.util.List;
+import java.util.stream.Collectors;
 import javax.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -34,5 +35,11 @@ public class Member {
     public void setRoles(List<Authority> roles) {
         this.authorities = roles;
         roles.forEach(o -> o.setMember(this));
+    }
+
+    public List<String> getAuthoritiesNames() {
+        return authorities.stream()
+                .map(Authority::getRoleName)
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/halo/eventer/domain/member/service/MemberService.java
+++ b/src/main/java/com/halo/eventer/domain/member/service/MemberService.java
@@ -1,6 +1,5 @@
 package com.halo.eventer.domain.member.service;
 
-
 import com.halo.eventer.domain.member.exception.LoginFailedException;
 import com.halo.eventer.domain.member.exception.MemberNotFoundException;
 import com.halo.eventer.domain.member.Member;
@@ -16,18 +15,16 @@ import org.springframework.stereotype.Service;
 @Service
 @RequiredArgsConstructor
 public class MemberService {
-    private final MemberRepository memberRepository;
-    private final PasswordEncoder encoder;
-    private final JwtProvider jwtProvider;
+  private final MemberRepository memberRepository;
+  private final PasswordEncoder encoder;
+  private final JwtProvider jwtProvider;
 
-    public TokenDto login(LoginDto loginDto) throws BaseException {
-    Member member = memberRepository.findByLoginId(loginDto.getLoginId())
-            .orElseThrow(MemberNotFoundException::new);
-        if(!encoder.matches(loginDto.getPassword(), member.getPassword())) {
+  public TokenDto login(LoginDto loginDto) throws BaseException {
+    Member member = memberRepository.findByLoginId(loginDto.getLoginId()).orElseThrow(MemberNotFoundException::new);
+    if (!encoder.matches(loginDto.getPassword(), member.getPassword())) {
       throw new LoginFailedException();
-        }
-
-        return new TokenDto(jwtProvider.createToken(member.getLoginId(),member.getRoleNames()));
-        //return jwtProvider.createToken(member.getLoginId(),member.getAuthorities());
     }
+
+    return new TokenDto(jwtProvider.createToken(member.getLoginId(), member.getRoleNames()));
+  }
 }

--- a/src/main/java/com/halo/eventer/domain/member/service/MemberService.java
+++ b/src/main/java/com/halo/eventer/domain/member/service/MemberService.java
@@ -27,7 +27,7 @@ public class MemberService {
       throw new LoginFailedException();
         }
 
-        return new TokenDto(jwtProvider.createToken(member.getLoginId(),member.getAuthorities()));
+        return new TokenDto(jwtProvider.createToken(member.getLoginId(),member.getAuthoritiesNames()));
         //return jwtProvider.createToken(member.getLoginId(),member.getAuthorities());
     }
 }

--- a/src/main/java/com/halo/eventer/domain/member/service/MemberService.java
+++ b/src/main/java/com/halo/eventer/domain/member/service/MemberService.java
@@ -27,7 +27,7 @@ public class MemberService {
       throw new LoginFailedException();
         }
 
-        return new TokenDto(jwtProvider.createToken(member.getLoginId(),member.getAuthoritiesNames()));
+        return new TokenDto(jwtProvider.createToken(member.getLoginId(),member.getRoleNames()));
         //return jwtProvider.createToken(member.getLoginId(),member.getAuthorities());
     }
 }

--- a/src/main/java/com/halo/eventer/global/security/provider/JwtProvider.java
+++ b/src/main/java/com/halo/eventer/global/security/provider/JwtProvider.java
@@ -1,6 +1,5 @@
 package com.halo.eventer.global.security.provider;
 
-import com.halo.eventer.domain.member.Authority;
 import com.halo.eventer.global.security.CustomUserDetailsService;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jws;
@@ -40,7 +39,7 @@ public class JwtProvider {
     this.key = Keys.hmacShaKeyFor(Decoders.BASE64.decode(secret));
   }
 
-  public String createToken(String account, List<Authority> roles) {
+  public String createToken(String account, List<String> roles) {
     Claims claims = Jwts.claims().setSubject(account);
     claims.put("roles", roles);
     Date now = new Date();


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #105 

## 📝작업 내용

티켓팅 서비스를 만들어 나가던 중 JWT 토큰을 티켓팅 서비스에서도 사용해야해서 필요한 부분만 추가하고 있었는데 JWT Claim에 불필요하게 Authority 객체가 담기고 있음을 확인하였습니다. 

따라서 1차적으로 Authority 객체에서 권한 이름만 담는 형식으로 변경하였습니다.

변경전
```
"roles": [
    {
      "id": 1,
      "roleName": "ROLE_ADMIN"
    }
  ],
```

변경후
```
  "roles": [
    "ROLE_ADMIN"
  ],
```
